### PR TITLE
Update pandas for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dash==2.14.1
 requests==2.31.0
 plotly==5.18.0
-pandas==2.1.2
+pandas==2.2.3
 gunicorn==21.2.0
 
 


### PR DESCRIPTION
## Summary
- update the pandas dependency to 2.2.3 so wheels are available for Python 3.13 environments

## Testing
- python -m pip install -r requirements.txt *(fails: Cannot connect to proxy., OSError('Tunnel connection failed: 403 Forbidden'))*

------
https://chatgpt.com/codex/tasks/task_e_68cb6673210c8332b455e68431ff7b12