### PR TITLE
Add borough color legend to dashboard side panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,14 @@ borough_colors = {
     "Staten Island": "#8D82B6"
 }
 
+legend_items = [
+    html.Div([
+        html.Span(style={'backgroundColor': color}, className='legend-color-box'),
+        html.Span(borough, className='legend-label')
+    ], className='legend-item')
+    for borough, color in borough_colors.items()
+]
+
 custom_background_color = '#222'
 #https://dash-example-index.herokuapp.com/cheatsheet
 
@@ -72,12 +80,16 @@ app.layout = html.Div([
         html.Div([
             html.Div(
                 dcc.Markdown("""
-                    Arrest data is sourced from the NYS Open Data Program and covers all years from 2006 to 2022. 
-                             
+                    Arrest data is sourced from the NYS Open Data Program and covers all years from 2006 to 2022.
+
                     This dataset is updated annually and was initially released to the public in 2018.
                     """),
                 className='static-text-box'
             ),
+            html.Div([
+                html.H3("Borough Colors", className='legend-title'),
+                *legend_items
+            ], className='legend-container'),
             html.Label("Map Type:", className='dropdown-label',style={'color': '#FFFFFF'}),
             # Toggles for the map type
             dcc.RadioItems(

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -99,6 +99,47 @@ body {
   font-family: Helvetica;
 }
 
+.legend-container {
+  background-color: #222;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 20px;
+  font-family: Helvetica, sans-serif;
+}
+
+.legend-title {
+  margin: 0 0 12px;
+  font-size: 18px;
+  color: #D6D7D7;
+  font-family: Helvetica, sans-serif;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.legend-item:last-child {
+  margin-bottom: 0;
+}
+
+.legend-color-box {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid #555;
+  display: inline-block;
+}
+
+.legend-label {
+  color: #ffffff;
+  font-family: Helvetica, sans-serif;
+}
+
 .dropdown-container {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- add a styled borough color legend to the left-hand side panel so chart colors are easier to interpret
- define supporting legend styles to match the dashboard's existing visual theme

## Testing
- python -m compileall app.py processing.py

------
https://chatgpt.com/codex/tasks/task_e_68cb699c130c83329022eb8ae4701562